### PR TITLE
모든 요청에 스마트폰의 User-Agent를 사용하도록 설정.

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -45,6 +45,8 @@ KORAIL_EVENT = "%s.common.event" % KORAIL_MOBILE
 KORAIL_PAYMENT = "%s/ebizmw/PrdPkgMainList.do" % KORAIL_DOMAIN
 KORAIL_PAYMENT_VOUCHER = "%s/ebizmw/PrdPkgBoucherView.do" % KORAIL_DOMAIN
 
+DEFAULT_USER_AGENT = "Dalvik/2.1.0 (Linux; U; Android 5.1.1; Nexus 4 Build/LMY48T)"
+
 
 def _get_utf8(data, key, default=None):
     v = data.get(key, default)
@@ -501,6 +503,7 @@ class Korail(object):
     email = None
 
     def __init__(self, korail_id, korail_pw, auto_login=True, want_feedback=False):
+        self._session.headers.update({'User-Agent': DEFAULT_USER_AGENT})
         self.korail_id = korail_id
         self.korail_pw = korail_pw
         self.want_feedback = want_feedback


### PR DESCRIPTION
Requests 기본 User-Agent로 요청하면
```json
{
  "h_msg_txt" : "[1]접근정보에 문제가 있습니다.",
  "h_msg_cd" : "[1]접근정보에 문제가 있습니다.",
  "strResult" : "SUCC"
}
```
과 같은 에러 메시지가 옵니다. 현재 열려있는 #23 이슈도 해결 될 것이라 생각합니다.