### PR TITLE
hotfix: 코레일에 일정 찾기 API 요청보낼때 파라미터 값 수정(txtGoHour)

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -729,10 +729,12 @@ There are 3 types of Passengers now, AdultPassenger, ChildPassenger and SeniorPa
     ...
 
 """
+        # NOTE: 버그 수정. 코레일에 열차 티켓 리스트 API 요청시 한국시간을 기준으로 함.
+        kst = timezone(timedelta(hours=9))
         if date is None:
-            date = datetime.now().strftime("%Y%m%d")
+            date = datetime.utcnow().astimezone(kst).strftime("%Y%m%d")
         if time is None:
-            time = datetime.now().strftime("%H%M%S")
+            time = datetime.utcnow().astimezone(kst).strftime("%H%M%S")
 
         if passengers is None:
             passengers = [AdultPassenger()]


### PR DESCRIPTION
- 한국시간대가 아닌 서버에서 datetime.now()를 하면 해당 서버의 시간대가 나옵니다. 이로 인해서 한국시간대의 티켓 정보를 제대로 요청할 수 없어서 서버 timezone에 해당하는 시간을 utc 기준으로 변경한뒤 다시 한국시간대로 변경했습니다. (테스트 성공)
- 버그 파악 방법은 다른 timezone 서버에서 search_train 메소드를 실행시켜서 return 값을 보면 알 수 있습니다.