### PR TITLE
use_2to3로 인한 설치 오류

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,4 @@ setup(
         'requests',
         'six'
     ],
-    use_2to3=True
 )

--- a/test/test_korail.py
+++ b/test/test_korail.py
@@ -149,11 +149,11 @@ class TestKorail(TestCase):
     def test_search_train(self):
         trains = self.korail.search_train("서울", "부산", self.thetime().strftime("%Y%m%d"), "100000")
         self.assertGreaterEqual(len(trains), 0, "tomorrow train search")
-        print trains
+        print(trains)
 
         alltrains = self.korail.search_train_allday("서울", "부산", self.thetime().strftime("%Y%m%d"), "100000")
         self.assertGreaterEqual(len(alltrains), len(trains), "tomorrow train search")
-        print alltrains
+        print(alltrains)
 
     # def test_reserve(self):
     # self.skipTest("Same to test_cancel")
@@ -173,7 +173,7 @@ class TestKorail(TestCase):
             self.assertIsNotNone(reserves, "get reservation list")
             self.assertIsInstance(reserves, list)
 
-            # print reserves
+            # print(reserves)
         except Exception:
             self.fail(e.message)
             # self.skipTest(e.message)
@@ -239,7 +239,7 @@ class TestKorail(TestCase):
         except NoResultsError:
             self.skipTest("Sold out")
 
-        print trains
+        print(trains)
         empty_seats = filter(lambda x: "11" in (x.special_seat, x.general_seat), trains)
         if len(empty_seats) > 0:
             try:

--- a/test/test_korail.py
+++ b/test/test_korail.py
@@ -109,14 +109,14 @@ class TestKorail(TestCase):
     def test__result_check(self):
         try:
             self.korail._result_check({})
-        except KorailError, e:
+        except KorailError:
             self.assertTrue(False)
-        except Exception, e:
+        except Exception:
             self.assertTrue(True)
 
         try:
             self.korail._result_check({"strResult": "SUCC", "h_msg_cd": "P000", "h_msg_txt": "UNKNOWN"})
-        except Exception, e:
+        except Exception:
             self.assertTrue(False)
         else:
             self.assertTrue(True)
@@ -125,7 +125,7 @@ class TestKorail(TestCase):
             self.korail._result_check({"strResult": "FAIL", "h_msg_cd": "P000", "h_msg_txt": "UNKNOWN"})
         except KorailError:
             self.assertTrue(True)
-        except Exception, e:
+        except Exception:
             self.assertTrue(False)
 
         try:
@@ -134,7 +134,7 @@ class TestKorail(TestCase):
             self.assertTrue(True)
         except KorailError:
             self.assertTrue(False)
-        except Exception, e:
+        except Exception:
             self.assertTrue(False)
 
         try:
@@ -143,7 +143,7 @@ class TestKorail(TestCase):
             self.assertTrue(True)
         except KorailError:
             self.assertTrue(False)
-        except Exception, e:
+        except Exception:
             self.assertTrue(False)
 
     def test_search_train(self):
@@ -174,7 +174,7 @@ class TestKorail(TestCase):
             self.assertIsInstance(reserves, list)
 
             # print reserves
-        except Exception, e:
+        except Exception:
             self.fail(e.message)
             # self.skipTest(e.message)
 


### PR DESCRIPTION
1. 문제 상황
`setuptools`의 `setup`에서 받는 키워드 인자에서 `use_2to3`가 사라졌습니다. 그래서 최신 버전의 파이썬을 사용할 때 에러가 발생하는 경우가 있습니다.

2. 해결
`setup` 함수의 파라미터에서 `use_2to3`를 지웠습니다. 코드를 읽어본 결과 버전으로 인한 오류는 없을 것으로 판단됩니다.