### PR TITLE
Remove debug print

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -847,7 +847,8 @@ There are 4 options in ReserveOption class.
         if passengers is None:
             passengers = [AdultPassenger()]
 
-        print(train)
+        if self.want_feedback:
+            print(train)
 
         passengers = Passenger.reduce(passengers)
         cnt = reduce(lambda x,y: x + y.count, passengers, 0)

--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -12,7 +12,6 @@ import itertools
 import sys
 from datetime import datetime, timedelta
 from six import with_metaclass
-from pprint import pprint
 from datetime import timezone
 
 try:


### PR DESCRIPTION
`Korail.reserve` 함수에 예매할 기차의 정보를 출력하는 라인이 덩그러니 있어서 `want_feedback` 플래그가 설정된 경우에만 출력하도록 수정했습니다.

추가로 `pprint` 모듈을 가져오는데, `want_feedback`과 관련된 다른 출력에서도 기본 `print`문을 사용하고 `pprint` 모듈은 쓰이는 곳이 없어서 해당 `import` 라인은 삭제했습니다.