### PR TITLE
Fix issue #38 and `Korail._session` is now a instance var

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -516,7 +516,6 @@ class SoldOutError(KorailError):
 # noinspection PyUnresolvedReferences,PyRedeclaration
 class Korail(object):
     """Korail object"""
-    _session = requests.session()
 
     _device = 'AD'
     _version = '190617001'
@@ -527,6 +526,7 @@ class Korail(object):
     email = None
 
     def __init__(self, korail_id, korail_pw, auto_login=True, want_feedback=False):
+        self._session = requests.Session()
         self._session.headers.update({'User-Agent': DEFAULT_USER_AGENT})
         self.korail_id = korail_id
         self.korail_pw = korail_pw


### PR DESCRIPTION
서로 다른 계정으로 로그인한 객체를 만들 수 있습니다.

```python
k1 = Korail(U1, P1)
k2 = Korail(U2, P2)
```

기존에는 위 코드에서 두 객체가 U2로 로그인한 같은 세션을 공유한다는 문제가 있었습니다.
수정을 통해 두 객체는 U1, U2로 로그인한 서로 다른 세션을 가집니다.

---

참고로 `requests.session()`이 아니라 `requests.Session()`으로 선언했는데, `requests` 모듈에서 여전히 `session`과 하위 호환성을 유지하고 있지만 최신은 `Session`이라 이렇게 변경했습니다.