### PR TITLE
fix: 로그인 문제 해결

### DIFF
--- a/korail2/korail2.py
+++ b/korail2/korail2.py
@@ -10,10 +10,14 @@ import re
 import requests
 import itertools
 import sys
+import base64
+
 from datetime import datetime, timedelta
 from six import with_metaclass
 from pprint import pprint
 from datetime import timezone
+from Crypto.Util.Padding import pad
+from Crypto.Cipher import AES
 
 try:
     # noinspection PyPackageRequirements
@@ -55,6 +59,8 @@ KORAIL_EVENT = "%s.common.event" % KORAIL_MOBILE
 KORAIL_PAYMENT = "%s/ebizmw/PrdPkgMainList.do" % KORAIL_DOMAIN
 KORAIL_PAYMENT_VOUCHER = "%s/ebizmw/PrdPkgBoucherView.do" % KORAIL_DOMAIN
 
+KORAIL_CODE = "%s.common.code.do" % KORAIL_MOBILE
+
 DEFAULT_USER_AGENT = "Dalvik/2.1.0 (Linux; U; Android 5.1.1; Nexus 4 Build/LMY48T)"
 
 
@@ -68,7 +74,6 @@ def _get_utf8(data, key, default=None):
         return v.encode('utf-8')
     else:
         return v
-
 
 class Schedule(object):
     """Korail train object. Highly inspired by `korail.py
@@ -522,6 +527,8 @@ class Korail(object):
     _version = '190617001'
     _key = 'korail1234567890'
 
+    _idx = None
+
     membership_number = None
     name = None
     email = None
@@ -534,6 +541,30 @@ class Korail(object):
         self.logined = False
         if auto_login:
             self.login(korail_id, korail_pw)
+
+    def __enc_password(self, password):
+        url = KORAIL_CODE
+        data = {
+            'code': "app.login.cphd"
+        }
+
+        r = self._session.post(url, data=data)
+        j = json.loads(r.text)
+
+        if j['strResult'] == 'SUCC' and j.get('app.login.cphd') is not None:
+            self._idx = j['app.login.cphd']['idx']
+            key = j['app.login.cphd']['key']
+
+            encrypt_key = key.encode(encoding='utf-8', errors='strict')
+            iv = key[:16].encode(encoding='utf-8', errors='strict')
+            cipher = AES.new(encrypt_key, AES.MODE_CBC, iv)
+            
+            padded_data = pad(password.encode("utf-8"), AES.block_size)
+
+            return base64.b64encode(base64.b64encode(cipher.encrypt(padded_data))).decode("utf-8")
+        else:
+            return False
+
 
     def login(self, korail_id=None, korail_pw=None):
         """Login to Korail server.
@@ -583,14 +614,15 @@ When you want change ID using existing object,
         url = KORAIL_LOGIN
         data = {
             'Device': self._device,
-            'Version': '150718001', # HACK
+            'Version': '231231001', # HACK
             #'Version': self._version,
             # 2 : for membership number,
             # 4 : for phone number,
             # 5 : for email,
             'txtInputFlg': txt_input_flg,
             'txtMemberNo': korail_id,
-            'txtPwd': korail_pw
+            'txtPwd': self.__enc_password(korail_pw),
+            'idx': self._idx
         }
 
         r = self._session.post(url, data=data)

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     ],
     install_requires=[
         'requests',
-        'six'
+        'six',
+        'PyCryptodome'
     ],
 )


### PR DESCRIPTION
## 문제
- 로그인 시도 시 `{'h_msg_cd': 'SUPDATE', 'strResult': 'SUCC', 'h_msg_txt': '최신버전으로 업데이트하신 후 이용하여 주십시오.'}` 오류가 발생하는 것을 확인했습니다.
- 이에 대응해 로그인 요청의 `Version`을  `231231001`로 변경하였으나 또 다른 `{'h_msg_cd' : 'S003', 'strResult' : 'SUCC', 'h_msg_txt' : '서비스에 문제가 발생하였습니다.\n\n잠시 후 다시 이용하여 주시기바랍니다.\n이용에 불편을 드려 죄송합니다.'}` 문제가 발생합니다. 

내부 버전이 '231231001'로 올라감에 따라 **로그인 시 비밀번호 전달 방식이 변경**되었습니다.
기존 `txtPwd` 매개변수에 비밀번호 원문을 보내는 방식에서 이제 비밀번호를 **AES암호화 후 base64로 인코딩하여 로그인**합니다.

## 해결
`https://smart.letskorail.com/classes/com.korail.mobile.common.code.do`에서 AES 암호화에 필요한 `key`, 추후 검증에 사용되는 `idx` 값을 요청할 수 있습니다. 
위 값을 이용해 알맞게 암호화하여 값을 전송합니다.

## 비고
- 암호화를 위해 PyCryptodome 모듈을 추가하였습니다.
- 하루 동안 확인한 결과 `idx`의 값과 `key`값은 **일대일 관계**이며 **변하지 않음**을 확인했습니다. 하지만 추후 안정성을 위해 매 로그인마다 값을 요청합니다.

fix #47 